### PR TITLE
esp_simplefoc: remove from dependencies

### DIFF
--- a/idf_component.yml
+++ b/idf_component.yml
@@ -11,8 +11,6 @@ targets:
 dependencies:
   idf:
     version: ">=4.4"
-  esp_simplefoc:
-    version: "*"
 files:
   exclude:
     - "examples/**/*"


### PR DESCRIPTION
As esp_simplefoc has not been published yet, esp-registry refused to accept the component depending on that.

Solution:
* Remove the `esp_simplefoc` from dependencies of `arduino-foc`
* In `esp_simplefoc` CMakeLists.txt, add dependency through:

```cmake
idf_component_get_property(arduino-foc_lib espressif__arduino-foc COMPONENT_LIB)
cmake_policy(SET CMP0079 NEW)
target_link_libraries(${arduino-foc_lib} PRIVATE ${COMPONENT_LIB})

```