### PR TITLE
remove Arduino.h and replace it with esp_platform.h to fit esp_simplefoc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ChangeLog
 
+## v2.3.0~1 - 2023-07-20
+
+* Replace Arduino with esp_platform implementations
+
 ## v2.3.0 - 2023-07-11
 
 * Based on [Arduino-FOC v2.3.0](https://github.com/simplefoc/Arduino-FOC/releases/tag/v2.3.0)

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,4 +1,4 @@
-version: "2.3.0"
+version: "2.3.0~1"
 description: Arduino FOC for BLDC and Stepper motors (SimpleFOC)
 url: https://github.com/espressif/Arduino-FOC
 repository: https://github.com/espressif/Arduino-FOC.git

--- a/src/BLDCMotor.h
+++ b/src/BLDCMotor.h
@@ -1,7 +1,7 @@
 #ifndef BLDCMotor_h
 #define BLDCMotor_h
 
-#include "Arduino.h"
+#include "esp_platform.h"
 #include "common/base_classes/FOCMotor.h"
 #include "common/base_classes/Sensor.h"
 #include "common/base_classes/BLDCDriver.h"

--- a/src/StepperMotor.h
+++ b/src/StepperMotor.h
@@ -6,7 +6,7 @@
 #ifndef StepperMotor_h
 #define StepperMotor_h
 
-#include "Arduino.h"
+#include "esp_platform.h"
 #include "common/base_classes/FOCMotor.h"
 #include "common/base_classes/StepperDriver.h"
 #include "common/base_classes/Sensor.h"

--- a/src/common/base_classes/BLDCDriver.h
+++ b/src/common/base_classes/BLDCDriver.h
@@ -1,7 +1,7 @@
 #ifndef BLDCDRIVER_H
 #define BLDCDRIVER_H
 
-#include "Arduino.h"
+#include "esp_platform.h"
 
 
 enum PhaseState : uint8_t {

--- a/src/common/base_classes/FOCMotor.h
+++ b/src/common/base_classes/FOCMotor.h
@@ -1,7 +1,7 @@
 #ifndef FOCMOTOR_H
 #define FOCMOTOR_H
 
-#include "Arduino.h"
+#include "esp_platform.h"
 #include "Sensor.h"
 #include "CurrentSense.h"
 

--- a/src/common/foc_utils.h
+++ b/src/common/foc_utils.h
@@ -1,7 +1,7 @@
 #ifndef FOCUTILS_LIB_H
 #define FOCUTILS_LIB_H
 
-#include "Arduino.h"
+#include "esp_platform.h"
 
 // sign function
 #define _sign(a) ( ( (a) < 0 )  ?  -1   : ( (a) > 0 ) )

--- a/src/communication/Commander.h
+++ b/src/communication/Commander.h
@@ -1,7 +1,7 @@
 #ifndef COMMANDS_H
 #define COMMANDS_H
 
-#include "Arduino.h"
+#include "esp_platform.h"
 #include "../common/base_classes/FOCMotor.h"
 #include "../common/pid.h"
 #include "../common/lowpass_filter.h"

--- a/src/communication/SimpleFOCDebug.h
+++ b/src/communication/SimpleFOCDebug.h
@@ -2,7 +2,7 @@
 #ifndef __SIMPLEFOCDEBUG_H__
 #define __SIMPLEFOCDEBUG_H__
 
-#include "Arduino.h"
+#include "esp_platform.h"
 
 
 /**

--- a/src/communication/StepDirListener.h
+++ b/src/communication/StepDirListener.h
@@ -1,7 +1,7 @@
 #ifndef STEPDIR_H
 #define STEPDIR_H
 
-#include "Arduino.h"
+#include "esp_platform.h"
 #include "../common/foc_utils.h"
 
 

--- a/src/current_sense/GenericCurrentSense.h
+++ b/src/current_sense/GenericCurrentSense.h
@@ -1,7 +1,7 @@
 #ifndef GENERIC_CS_LIB_H
 #define GENERIC_CS_LIB_H
 
-#include "Arduino.h"
+#include "esp_platform.h"
 #include "../common/foc_utils.h"
 #include "../common/time_utils.h"
 #include "../common/defaults.h"

--- a/src/current_sense/InlineCurrentSense.h
+++ b/src/current_sense/InlineCurrentSense.h
@@ -1,7 +1,7 @@
 #ifndef INLINE_CS_LIB_H
 #define INLINE_CS_LIB_H
 
-#include "Arduino.h"
+#include "esp_platform.h"
 #include "../common/foc_utils.h"
 #include "../common/time_utils.h"
 #include "../common/defaults.h"

--- a/src/current_sense/LowsideCurrentSense.h
+++ b/src/current_sense/LowsideCurrentSense.h
@@ -1,7 +1,7 @@
 #ifndef LOWSIDE_CS_LIB_H
 #define LOWSIDE_CS_LIB_H
 
-#include "Arduino.h"
+#include "esp_platform.h"
 #include "../common/foc_utils.h"
 #include "../common/time_utils.h"
 #include "../common/defaults.h"

--- a/src/sensors/Encoder.h
+++ b/src/sensors/Encoder.h
@@ -1,7 +1,7 @@
 #ifndef ENCODER_LIB_H
 #define ENCODER_LIB_H
 
-#include "Arduino.h"
+#include "esp_platform.h"
 #include "../common/foc_utils.h"
 #include "../common/time_utils.h"
 #include "../common/base_classes/Sensor.h"

--- a/src/sensors/GenericSensor.h
+++ b/src/sensors/GenericSensor.h
@@ -1,7 +1,7 @@
 #ifndef GENERIC_SENSOR_LIB_H
 #define GENERIC_SENSOR_LIB_H
 
-#include "Arduino.h"
+#include "esp_platform.h"
 #include "../common/foc_utils.h"
 #include "../common/time_utils.h"
 #include "../common/base_classes/Sensor.h"

--- a/src/sensors/HallSensor.h
+++ b/src/sensors/HallSensor.h
@@ -1,7 +1,7 @@
 #ifndef HALL_SENSOR_LIB_H
 #define HALL_SENSOR_LIB_H
 
-#include "Arduino.h"
+#include "esp_platform.h"
 #include "../common/base_classes/Sensor.h"
 #include "../common/foc_utils.h"
 #include "../common/time_utils.h"


### PR DESCRIPTION
we remove `Arduino.h` and replace it with `esp_platform.h` to fit `esp_simplefoc`.